### PR TITLE
Supported ISO 8601 format without subseconds.

### DIFF
--- a/Sources/PerfectCRUD/PerfectCRUD.swift
+++ b/Sources/PerfectCRUD/PerfectCRUD.swift
@@ -421,6 +421,11 @@ public extension Date {
 			self = d
 			return
 		}
+		dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ssx"
+		if let d = dateFormatter.date(from: string) {
+			self = d
+			return
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
Hello,

I found Postgres may outputs ISO 8601 format without subseconds, and fixed CRUD's parser to support it.